### PR TITLE
Adding genre array to description

### DIFF
--- a/models/descriptions.js
+++ b/models/descriptions.js
@@ -1,4 +1,5 @@
 const db = require("../data/db.js");
+const genreDB = require("./genres");
 
 const getTitleByPID = async (product_id) => {
   let title = await db
@@ -15,7 +16,13 @@ const getDescriptionByPID = async (product_id) => {
     .from("descriptions")
     .where({ product_id });
 
-  return description[0];
+  description = description[0];
+
+  let genres = await genreDB.getGenresByPID(product_id);
+
+  description = { ...description, genres };
+
+  return description;
 };
 
 module.exports = {


### PR DESCRIPTION
Per the planning document, adding the genres array to the description object returned from `GET /description/:product_id`